### PR TITLE
uncomment wireguard role

### DIFF
--- a/after-19-wireguard-01/ansible/setup.yml
+++ b/after-19-wireguard-01/ansible/setup.yml
@@ -2,7 +2,7 @@
   roles:
     # - hostname
     # - essentials
-    - security
+    # - security
     # - sysctl
     # - certbot
-    # - wireguard
+    - wireguard


### PR DESCRIPTION
This may be needed to run the wireguard role. 

In wireguard part 2, the security role needs to be used and not the wireguard role. Here, in part 1, it seems like opposite is true.